### PR TITLE
Clean up php notices

### DIFF
--- a/schema-store.php
+++ b/schema-store.php
@@ -82,25 +82,25 @@ class SchemaStore {
 		}
 		
 		$result = "";
-		if ($baseParts['scheme']) {
+		if (isset($baseParts['scheme'])) {
 			$result .= $baseParts['scheme']."://";
-			if ($baseParts['user']) {
+			if (isset($baseParts['user'])) {
 				$result .= ":".$baseParts['user'];
-				if ($baseParts['pass']) {
+				if (isset($baseParts['pass'])) {
 					$result .= ":".$baseParts['pass'];
 				}
 				$result .= "@";
 			}
 			$result .= $baseParts['host'];
-			if ($baseParts['port']) {
+			if (isset($baseParts['port'])) {
 				$result .= ":".$baseParts['port'];
 			}
 		}
 		$result .= $baseParts["path"];
-		if ($baseParts['query']) {
+		if (isset($baseParts['query'])) {
 			$result .= "?".$baseParts['query'];
 		}
-		if ($baseParts['fragment']) {
+		if (isset($baseParts['fragment'])) {
 			$result .= "#".$baseParts['fragment'];
 		}
 		return $result;
@@ -137,7 +137,7 @@ class SchemaStore {
 		}
 	}
 	
-	private function normalizeSchema($url, &$schema, $trustPrefix) {
+	private function normalizeSchema($url, &$schema, $trustPrefix = '') {
 		if (is_array($schema) && !self::isNumericArray($schema)) {
 			$schema = (object)$schema;
 		}
@@ -155,15 +155,9 @@ class SchemaStore {
 				}
 			} else if (isset($schema->id)) {
 				$schema->id = $url = self::resolveUrl($url, $schema->id);
-				if ($trustPrefix === TRUE
-						|| (substr($schema->id, 0, strlen($trustPrefix)) == $trustPrefix
-							&& ($trustPrefix[strlen($trustPrefix) - 1] == "/"
-								|| $schema->id[strlen($trustPrefix)] == "#"
-								|| $schema->id[strlen($trustPrefix)] == "?")
-						)) {
-					if (!isset($this->schemas[$schema->id])) {
-						$this->add($schema->id, $schema);
-					}
+				$regex = '/^'.preg_quote($trustPrefix, '/').'(?:[#\/?].*)?$/';
+				if (($trustPrefix === TRUE || preg_match($regex, $schema->id)) && !isset($this->schemas[$schema->id])) {
+					$this->add($schema->id, $schema);
 				}
 			}
 			foreach ($schema as $key => &$value) {

--- a/tests/03 - schema store/02 - add using id.php
+++ b/tests/03 - schema store/02 - add using id.php
@@ -12,6 +12,24 @@ $schema = json_decode('{
 		},
 		"bar": {
 			"id": "/bar"
+		},
+		"baz": {
+			"id": "?baz=1"
+		},
+		"foobar": {
+			"id": "test-schema/foobar"
+		},
+		"nestedSchema": {
+			"id": "/test-schema/foo",
+			"nested": {
+				"id": "#bar"
+			}
+		},
+		"testSchemaFoo": {
+		    "id": "/test-schema-foo"
+		},
+		"somewhereElse": {
+			"id": "http://somewhere-else.com/test-schema"
 		}
 	}
 }');
@@ -22,8 +40,28 @@ if (!recursiveEqual($store->get($url."#foo"), $schema->properties->foo)) {
 	throw new Exception("#foo not found");
 }
 
+if (!recursiveEqual($store->get($url."?baz=1"), $schema->properties->baz)) {
+	throw new Exception("?baz=1 not found");
+}
+
+if (!recursiveEqual($store->get($url."/foobar"), $schema->properties->foobar)) {
+	throw new Exception("/foobar not found");
+}
+
+if (!recursiveEqual($store->get($url."/foo#bar"), $schema->properties->nestedSchema->nested)) {
+	throw new Exception("/foo#bar not found");
+}
+
 if ($store->get($urlBase."bar")) {
 	throw new Exception("/bar should not be indexed, as it should not be trusted");
+}
+
+if ($store->get($url."-foo")) {
+	throw new Exception("/test-schema-foo should not be indexed, as it should not be trusted");
+}
+
+if ($store->get("http://somewhere-else.com/test-schema")) {
+	throw new Exception("http://somewhere-else.com/test-schema should not be indexed, as it should not be trusted");
 }
 
 $store->add($url, $schema, TRUE);

--- a/tests/03 - schema store/03 - references.php
+++ b/tests/03 - schema store/03 - references.php
@@ -50,7 +50,7 @@ $otherSchema = json_decode('{
 }');
 $store->add($urlBase."somewhere-else", $otherSchema);
 $fooSchema = $schema->properties->foo;
-if ($fooSchema->{'$ref'}) {
+if (property_exists($fooSchema, '$ref')) {
 	throw new Exception('$ref should have been resolved');
 }
 if ($fooSchema->title != "Somewhere else") {


### PR DESCRIPTION
As it is written, this library emits a bunch of php notices when php is running at higher error reporting levels.  This update cleans up those warnings.

I made one change that deserves critical review.  I changed the conditional statement starting on line 159 in schema-store.php.  The expressions on lines 161 and 162 were causing php notices. It seems that these lines are not really needed.  All tests passed when I removed them, but I am uncomfortable with the change because I'm not sure I fully grasp the intent of the statement.
