### PR TITLE
Fix normalizeSchema when schema is an array

### DIFF
--- a/schema-store.php
+++ b/schema-store.php
@@ -122,7 +122,7 @@ class SchemaStore {
 		$trustBase = $trustBase[0];
 
 		$this->schemas[$url] =& $schema;
-		$this->normaliseSchema($url, $schema, $trusted ? TRUE : $trustBase);
+		$this->normalizeSchema($url, $schema, $trusted ? TRUE : $trustBase);
 		if ($fragment == "") {
 			$this->schemas[$baseUrl] = $schema;
 		}
@@ -137,7 +137,7 @@ class SchemaStore {
 		}
 	}
 	
-	private function normaliseSchema($url, &$schema, $trustPrefix) {
+	private function normalizeSchema($url, &$schema, $trustPrefix) {
 		if (is_array($schema) && !self::isNumericArray($schema)) {
 			$schema = (object)$schema;
 		}
@@ -168,12 +168,12 @@ class SchemaStore {
 			}
 			foreach ($schema as $key => &$value) {
 				if ($key != "enum") {
-					self::normaliseSchema($url, $value, $trustPrefix);
+					self::normalizeSchema($url, $value, $trustPrefix);
 				}
 			}
 		} else if (is_array($schema)) {
 			foreach ($schema as &$value) {
-				self::normaliseSchema($value);
+				self::normalizeSchema($url, $value, $trustPrefix);
 			}
 		}
 	}

--- a/tests/03 - schema store/03 - references.php
+++ b/tests/03 - schema store/03 - references.php
@@ -44,7 +44,9 @@ if (!recursiveEqual($store->missing(), array($urlBase."somewhere-else"))) {
 
 $otherSchema = json_decode('{
 	"title": "Somewhere else",
-	"items": {"$ref": "'.$urlBase."test-schema-2".'"}
+	"items": [
+		{"$ref": "'.$urlBase."test-schema-2".'"}
+	]
 }');
 $store->add($urlBase."somewhere-else", $otherSchema);
 $fooSchema = $schema->properties->foo;
@@ -54,7 +56,7 @@ if ($fooSchema->{'$ref'}) {
 if ($fooSchema->title != "Somewhere else") {
 	throw new Exception('$ref does not point to correct place');
 }
-if ($fooSchema->items->title != "Test schema 2") {
+if ($fooSchema->items[0]->title != "Test schema 2") {
 	throw new Exception('$ref in somewhere-else was not resolved');
 }
 if (count($store->missing())) {


### PR DESCRIPTION
When the schema passed to normailzeSchema is an array of schemas, the function recursively calls itself for each schema in the array.  However, it is passing the wrong parameters to the function.  I also updated the tests to expose this bug.

I know the wrong parameters were being passed, but I am not sure I filled them in correctly.
