### PR TITLE
fixed issue where multiple $ref to the same resource would not resolve

### DIFF
--- a/schema-store.php
+++ b/schema-store.php
@@ -127,8 +127,10 @@ class SchemaStore {
 			$this->schemas[$baseUrl] = $schema;
 		}
 		if (isset($this->refs[$baseUrl])) {
-			foreach ($this->refs[$baseUrl] as $fullUrl => &$refSchema) {
-				$refSchema = $this->get($fullUrl);
+			foreach ($this->refs[$baseUrl] as $fullUrl => $refSchemas) {
+				foreach ($refSchemas as &$refSchema) {
+					$refSchema = $this->get($fullUrl);
+				}
 				unset($this->refs[$baseUrl][$fullUrl]);
 			}
 			if (count($this->refs[$baseUrl]) == 0) {
@@ -151,7 +153,7 @@ class SchemaStore {
 					$urlParts = explode("#", $refUrl);
 					$baseUrl = array_shift($urlParts);
 					$fragment = urldecode(implode("#", $urlParts));
-					$this->refs[$baseUrl][$refUrl] =& $schema;
+					$this->refs[$baseUrl][$refUrl][] =& $schema;
 				}
 			} else if (isset($schema->id)) {
 				$schema->id = $url = self::resolveUrl($url, $schema->id);

--- a/tests/03 - schema store/03 - references.php
+++ b/tests/03 - schema store/03 - references.php
@@ -63,4 +63,25 @@ if (count($store->missing())) {
 	throw new Exception('There should be no more missing schemas');
 }
 
+// Add external $ref twice
+$schema = json_decode('{
+	"title": "Test schema 3 a",
+	"properties": {
+		"foo1": {"$ref": "'.$urlBase.'test-schema-3-b#/foo"},
+		"foo2": {"$ref": "'.$urlBase.'test-schema-3-b#/foo"}
+	}
+}');
+$store->add($urlBase."test-schema-3-a", $schema);
+$schema = json_decode('{
+	"title": "Test schema 3 b",
+	"foo": {"type": "object"}
+}');
+$schema = $store->add($urlBase."test-schema-3-b", $schema);
+$schema = $store->get($urlBase."test-schema-3-a");
+if (property_exists($schema->properties->foo1, '$ref')) {
+	throw new Exception('$ref was not resolved for foo1');
+}
+if (property_exists($schema->properties->foo2, '$ref')) {
+	throw new Exception('$ref was not resolved for foo2');
+}
 ?>


### PR DESCRIPTION
Wrote a patch where if there are multiple `$ref`'s that point to the same resource, only one of them would get resolved. I've also added relevant unit tests.
