### PR TITLE
coerce additional properties if additionalProperties:false by discarding them

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,17 +49,23 @@ If it is successful, then a modified version of the data can be found in `$resul
 
 It's not psychic - in fact, it's quite limited.  What it currently does is:
 
-### Type-coercion for scalar types
+#### Type-coercion for scalar types
 
 Perhaps you are using data from `$_GET`, so everything's a string, but the schema says certain values should be integers or booleans.
 
 `Jsv4::coerce()` will attempt to convert strings to numbers/booleans *only where the schema says*, leaving other numerically-value strings as strings.
 
-### Missing properties
+#### Missing properties
 
 Perhaps the API needs a complete object (described using `"required"` in the schema), but only a partial one was supplied.
 
 `Jsv4::coerce()` will attempt to insert appropriate values for the missing properties, using a default (if it is defined in a nearby `"properties"` entry) or by creating a value if it knows the type.
+
+#### Additional properties
+
+Perhaps the client sends additional garbage to the API, and you want to filter them out right away:
+
+If `additionalProperties` is set to `false`, `Jsv4::coerce()` will remove any unknown properties at objects.
 
 ## The `SchemaStore` class
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "geraintluff/jsv4",
+	"name": "pogner-it/jsv4",
 	"description": "A (coercive) JSON Schema v4 Validator for PHP",
 	"keywords": ["JSON Schema", "JSON", "schema", "validator", "v4", "Geraint Luff", "geraintluff"],
 	"license": "MIT",

--- a/src/Jsv4/Validator.php
+++ b/src/Jsv4/Validator.php
@@ -309,7 +309,9 @@ class Validator
 				if (isset($checkedProperties[$key])) {
 					continue;
 				}
-				if (!$additionalProperties) {
+				if (!$additionalProperties and $this->coerce) {
+					unset($this->data->$key);
+				} else if(!$additionalProperties) {
 					$this->fail(self::OBJECT_ADDITIONAL_PROPERTIES, self::pointerJoin(array($key)), "/additionalProperties", "Additional properties not allowed");
 				} else if (is_object($additionalProperties)) {
 					$subResult = $this->subResult($subValue, $additionalProperties);

--- a/src/Jsv4/Validator.php
+++ b/src/Jsv4/Validator.php
@@ -48,7 +48,7 @@ class Validator
 		$this->firstErrorOnly	 = $firstErrorOnly;
 		$this->coerce			 = $coerce;
 		$this->valid			 = TRUE;
-		$this->errors			 = [];
+		$this->errors			 = array();
 
 		try {
 			$this->checkTypes();
@@ -179,7 +179,7 @@ class Validator
 		if (isset($this->schema->type)) {
 			$types = $this->schema->type;
 			if (!is_array($types)) {
-				$types = [$types];
+				$types = array($types);
 			}
 			foreach ($types as $type) {
 				if ($type == "object" && is_object($this->data)) {
@@ -282,7 +282,7 @@ class Validator
 				}
 			}
 		}
-		$checkedProperties = [];
+		$checkedProperties = array();
 		if (isset($this->schema->properties)) {
 			foreach ($this->schema->properties as $key => $subSchema) {
 				$checkedProperties[$key] = TRUE;
@@ -483,7 +483,7 @@ class Validator
 			}
 		}
 		if (isset($this->schema->anyOf)) {
-			$failResults = [];
+			$failResults = array();
 			foreach ($this->schema->anyOf as $index => $subSchema) {
 				$subResult = $this->subResult($this->data, $subSchema, FALSE);
 				if ($subResult->valid) {
@@ -494,7 +494,7 @@ class Validator
 			$this->fail(self::ANY_OF_MISSING, "", "/anyOf", "Value must satisfy at least one of the options", $failResults);
 		}
 		if (isset($this->schema->oneOf)) {
-			$failResults	 = [];
+			$failResults	 = array();
 			$successIndex	 = NULL;
 			foreach ($this->schema->oneOf as $index => $subSchema) {
 				$subResult = $this->subResult($this->data, $subSchema, FALSE);
@@ -555,7 +555,7 @@ class Validator
 				} elseif (in_array("object", $types)) {
 					$this->data->$key = new \StdClass;
 				} elseif (in_array("array", $types)) {
-					$this->data->$key = [];
+					$this->data->$key = array();
 				} else {
 					return FALSE;
 				}

--- a/tests/02 - coercive validation/03 - additional properties.json
+++ b/tests/02 - coercive validation/03 - additional properties.json
@@ -1,0 +1,29 @@
+[
+	{
+		"method": "coerce",
+		"title": "discard additional properties from default",
+		"schema": {
+			"properties": {
+				"foo": {
+                    "type": "boolean"
+                },
+				"bar": {
+                    "type": "string",
+					"default": "default value"
+				}
+			},
+            "required": [ "foo" ],
+			"additionalProperties": false
+		},
+		"data": {
+			"foo": true,
+            "garbage": "i am not wanted"
+		},
+		"result": {
+			"/valid": true,
+			"/value": {
+				"foo": true
+			}
+		}
+	}
+]


### PR DESCRIPTION
I would consider it best-practice to not drag along unwanted properties the client might send. At the same time a strict API rejecting the whole json might not what best suits a particular project.

this pull request proposes to give the programmer the additional choice to coerce the client-json into complying by inelegantly unsetting the offending property.
